### PR TITLE
fix remark from pull #1

### DIFF
--- a/aa_houbolak/controllers.py
+++ b/aa_houbolak/controllers.py
@@ -24,10 +24,13 @@ class website_yenth(website_sale):
             return redirection
 
         def getField(post, sol_id, field, funct):
+            assert funct in [int, bool, str]
             try:
                 return funct(post.get('%s-%s' % (sol_id, field)))
             except:
-                return 0
+                if funct == str:
+                    return ''
+                return funct(0)
 
         if post:
             if post.get('color'):

--- a/aa_houbolak/models.py
+++ b/aa_houbolak/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, fields, api
+from openerp import models, fields
 from openerp.osv import osv
 
 
@@ -74,11 +74,9 @@ class sale_order_line_your_extension(osv.osv):
         rechts = False
         boven = False
         onder = False
-        kleur = ''
         barcode = ''
         boringen = ''
         opmerkingen = ''
-        kleur = ''
         if line.hoogte:
             hoogte = line.hoogte
         if line.breedte:
@@ -101,8 +99,6 @@ class sale_order_line_your_extension(osv.osv):
             boringen = line.boringen
         if line.opmerkingen:
             opmerkingen = line.opmerkingen
-        if self.kleurenpicker:
-            kleur = self.kleurenpicker
         ret['hoogte'] = hoogte
         ret['breedte'] = breedte
         ret['aantal'] = aantal
@@ -114,7 +110,6 @@ class sale_order_line_your_extension(osv.osv):
         ret['barcode'] = barcode
         ret['boringen'] = boringen
         ret['opmerkingen'] = opmerkingen
-        ret['kleurenpicker'] = kleur
         return ret
 
 
@@ -129,6 +124,11 @@ class sale_order_line_colorpicker(models.Model):
 class aa_houbolak_colorpicker_in_salemodel(models.Model):
     _inherit = 'sale.order'
     kleurenpicker = fields.Many2one('sale.order.colorpicker', 'Kleur')
+
+    def _prepare_invoice(self, cr, uid, order, lines, context=None):
+        res = super(aa_houbolak_colorpicker_in_salemodel, self)._prepare_invoice(cr, uid, order, lines, context=context)
+        res['kleurenpicker'] = order.kleurenpicker.id
+        return res
 
 
 #Add many2one (for color dropdown) to account.invoice

--- a/aa_houbolak/templates.xml
+++ b/aa_houbolak/templates.xml
@@ -78,7 +78,6 @@
                       <li><a href="/shop/cart" class="text-success">Review Order<span class="chevron"></span></a></li>
                       <li><a href="/shop/checkout" class="text-success">Shipping &amp; Billing<span class="chevron"></span></a></li>
                       <li class="text-primary">Extra<span class="chevron"></span></li>
-                      <li class="text-muted">Payment<span class="chevron"></span></li>
                       <li class="text-muted">Confirmation<span class="chevron"></span></li>
                   </ul>
                   <h1 class="mb32">Extra info</h1>


### PR DESCRIPTION
1. Why does the menu item 'Payment' shows up when I am on the Extra page but nowhere else?
Forgot to remove it from extra

2. Why isn't product_uom_qty not calculated and filled in the backend?
It works ! but because you have a /1000000, if you set small value, it will be set to 0. But if you try 10000 in hooghte and  20000 in breedte, the product_uom_qty will be 200

3. How can I transfer data from the quotation/order to the invoice for the colors? 
Take a look in sale.py fom sale module and you will see a method : "_prepare_invoice" (Similary to the "_prepare_invoice_line")

